### PR TITLE
Use add_js_file for Sphinx 4 compatibility

### DIFF
--- a/sphinxcontrib/twitter/__init__.py
+++ b/sphinxcontrib/twitter/__init__.py
@@ -44,7 +44,7 @@ def setup(app):
 
     from . import tweet, user, timeline
 
-    app.add_javascript('https://platform.twitter.com/widgets.js')
+    app.add_js_file('https://platform.twitter.com/widgets.js')
 
     app.add_node(tweet.tweet,
                  html=(tweet.visit, tweet.depart))


### PR DESCRIPTION
This uses `add_js_file` instead of `add_javascript` so that this extension now works with Sphinx >= 4

closes https://github.com/shomah4a/sphinx-tweet-embed/issues/7